### PR TITLE
Added logic to find the Wordpress base path in a Bedrock installation…

### DIFF
--- a/force-deactivate.txt
+++ b/force-deactivate.txt
@@ -115,12 +115,21 @@ function rl_deactivate_plugin( $plugin ) {
 
 }
 
+/**
+ * Helper function to find Wordpress base path.
+ */
 function find_wordpress_base_path() {
   $dir = dirname(__FILE__);
   do {
       //it is possible to check for other files here
-      if( file_exists($dir."/wp-config.php") ) {
+      if( file_exists($dir."/wp-load.php") ) {
           return $dir;
+      }
+      // The Bedrock wordpress structure's WP base path is not simply up the tree
+      // from the plugins directory; it's in the /web/wp directory.
+      // See https://roots.io/bedrock/docs/folder-structure/ for more info.
+      if (file_exists($dir."/wp")) {
+          return $dir."/wp";
       }
   } while( $dir = realpath("$dir/..") );
   return null;


### PR DESCRIPTION
Bedrock is a modern WordPress stack with an increasing install base. Its wordpress core files are not directly upstream from the plugins directory, so the helper function find_wordpress_base_path() in force-deactivate.txt cannot Wordpress' core files in a Bedrock installation.

This patch adds logic that finds Wordpress' core files in such an installation.

Best not to search for wp-config.php, as Bedrock stores that file in a directory above the Wordpress core files.

See https://roots.io/bedrock/docs/folder-structure/ for more info on Bedrock.