### PR TITLE
Fix notice message when zlib output compression is active

### DIFF
--- a/class-mixed-content-fixer.php
+++ b/class-mixed-content-fixer.php
@@ -104,7 +104,7 @@ if (!class_exists('rsssl_admin_mixed_content_fixer')) {
 
         public function end_buffer()
         {
-            if (ob_get_length()) ob_end_flush();
+            if (ob_get_length() && !ini_get('zlib.output_compression')) ob_end_flush();
         }
 
         /**


### PR DESCRIPTION
When zlib.output_compression is active, this function create a notice message "ob_end_flush(): failed to send buffer of zlib output compression (0)" in error_log and debug.log in every request.